### PR TITLE
guichan: build as static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,7 +534,7 @@ macro(vendored_guichan)
     ${CMAKE_CURRENT_MACRO_LIST_DIR}/guichan/include/guichan/widgets/textfield.hpp
     ${CMAKE_CURRENT_MACRO_LIST_DIR}/guichan/include/guichan/widgets/window.hpp
   )
-  add_library(guichan_lib ${guichan_SRCS} ${guichan_HDRS})
+  add_library(guichan_lib STATIC ${guichan_SRCS} ${guichan_HDRS})
   target_include_directories(guichan_lib SYSTEM PUBLIC ${CMAKE_CURRENT_MACRO_LIST_DIR}/guichan/include ${SDL2_INCLUDE_DIR})
   if (BUILD_VENDORED_SDL)
     add_dependencies(guichan_lib SDL2)


### PR DESCRIPTION
Otherwise it falls back to the global BUILD_SHARED_LIBS that might be set to ON. In that case the guichan lib needs to be installed together with stratagus.

Additionally STATIC is consistent with all other libs in this repo.
